### PR TITLE
Fix for MediaWiki 1.33

### DIFF
--- a/OAuth2Github.hooks.php
+++ b/OAuth2Github.hooks.php
@@ -1,12 +1,14 @@
 <?php
 
+use DatabaseUpdater;
+
 class OAuth2GithubHooks
 {
 
     public static function onBeforePageDisplay(OutputPage &$out, Skin &$skin)
     {
 
-        $script = '<link rel="stylesheet" type="text/css" href="/wiki/extensions/OAuth2Github/modules/OAuth2Github.css">';
+        $script = '<link rel="stylesheet" type="text/css" href="/extensions/MediaWiki-OAuth2-Github/modules/OAuth2Github.css">';
 
         $out->addHeadItem("jsonTree script", $script);
 
@@ -20,6 +22,15 @@ class OAuth2GithubHooks
         $header = $tpl->get('header');
         $header .= '<a class="mw-ui-button dataporten-button" href="' . Skin::makeSpecialUrlSubpage('OAuth2Github', 'redirect', 'returnto=' . $wgRequest->getVal('returnto')) . '">Login with Github</a>';
         $tpl->set('header', $header);
+    }
+
+    public static function onAuthChangeFormFields($requests, $fieldInfo, &$formDescriptor, $action) {
+        global $wgRequest;
+        $formDescriptor["github"] = [
+            'type' => 'info',
+            'default' => '<a class="mw-ui-button dataporten-button" href="' . Skin::makeSpecialUrlSubpage('OAuth2Github', 'redirect', 'returnto=' . $wgRequest->getVal('returnto')) . '">Login with Github</a>',
+            'raw' => true,
+        ];
     }
 
     public static function onUserLogout(&$user)

--- a/SpecialOAuth2Github.php
+++ b/SpecialOAuth2Github.php
@@ -218,7 +218,7 @@ class SpecialOAuth2Github extends SpecialPage
         }
         $user = User::newFromName($id, 'creatable');
         if (false === $user || $user->getId() != 0) {
-            throw new MWException('Unable to create user.');
+            throw new MWException('Unable to create user for \'' . $externalId . '\'.');
         }
         if (!$user->isLoggedIn()) {
             // [New in MW 1.27]

--- a/extension.json
+++ b/extension.json
@@ -28,6 +28,9 @@
     ],
     "LoadExtensionSchemaUpdates": [
       "OAuth2GithubHooks::onLoadExtensionSchemaUpdates"
+    ],
+    "AuthChangeFormFields": [
+      "OAuth2GithubHooks::onAuthChangeFormFields"
     ]
   },
   "ResourceFileModulePaths": {


### PR DESCRIPTION
The DB installation seems to be broken so I had to install it manually along with installing curl. But other than that this should fix support for MediaWiki 1.33.